### PR TITLE
Implement using 32bit address on 64bit

### DIFF
--- a/bdwgc/include/gc_mark.h
+++ b/bdwgc/include/gc_mark.h
@@ -324,7 +324,8 @@ struct GC_mark_custom_result {
  * Currently second choice is adopted,
  * but it can be changed in future for better performance.
  */
-typedef GC_word* (GC_get_next_pointer_proc)(GC_word* ptr, GC_word** next_ptr);
+typedef void (GC_get_next_pointer_proc)(GC_word* ptr, GC_word* end, GC_word** next_ptr,
+    GC_word** from, GC_word** to);
 GC_API struct GC_ms_entry* GC_mark_and_push_custom_iterable(GC_word* addr,
                                                    struct GC_ms_entry *mark_stack_ptr,
                                                    struct GC_ms_entry *mark_stack_limit,

--- a/bdwgc/mark.c
+++ b/bdwgc/mark.c
@@ -925,11 +925,13 @@ GC_API mse * GC_mark_and_push_custom_iterable(GC_word *addr, mse *mark_stack_ptr
     end = ((char*)addr) + GC_size(addr);
 
     GC_word* iterator = (GC_word*)start;
+    GC_word* next_ptr;
+    GC_word* from;
+    GC_word* to;
     while (TRUE) {
-        GC_word* next_ptr;
-        GC_word* point = proc(iterator, &next_ptr);
-        if (point) {
-            PUSH_CONTENTS((ptr_t)point, mark_stack_ptr, mark_stack_limit, (ptr_t)iterator);
+        proc(iterator, (GC_word*)end, &next_ptr, &from, &to);
+        if (to) {
+            PUSH_CONTENTS((ptr_t)to, mark_stack_ptr, mark_stack_limit, (ptr_t)from);
         }
         iterator = next_ptr;
         if (iterator >= (GC_word*)end)


### PR DESCRIPTION
* You can enable with ESCARGOT_USE_32BIT_IN_64BIT
* Optimize custom iterable mark functions

Signed-off-by: Seonghyun Kim <sh8281.kim@samsung.com>