### PR TITLE
When use 32bit pointer in 64bit,

### DIFF
--- a/LeakChecker.cpp
+++ b/LeakChecker.cpp
@@ -22,12 +22,6 @@ void HeapUsageVisualizer::initialize()
         fprintf(fp, "GC_no    PeakRSS   TotalHeap    Marked  # Phase\n");
         fclose(fp);
     }
-    GC_add_event_callback([](GC_EventType evtType, void*) {
-        if (GC_EVENT_RECLAIM_START == evtType) {
-            GC_dump_for_graph(HeapUsageVisualizer::m_outputFile.c_str(),
-                              s_gcLogPhaseName.c_str());
-        }
-    }, nullptr);
 }
 
 

--- a/bdwgc/include/private/gc_priv.h
+++ b/bdwgc/include/private/gc_priv.h
@@ -2273,7 +2273,7 @@ GC_API_PRIV void GC_log_printf(const char * format, ...)
   /* GC_verbose_log_printf is called only if GC_print_stats is VERBOSE. */
 # define GC_verbose_log_printf GC_log_printf
 #else
-  extern GC_bool GC_quiet;
+  extern GC_bool MAY_THREAD_LOCAL GC_quiet;
 # define GC_PRINT_STATS_FLAG (!GC_quiet)
   /* INFO/DBG loggers are enabled even if GC_print_stats is off. */
 # ifndef GC_INFOLOG_PRINTF

--- a/bdwgc/os_dep.c
+++ b/bdwgc/os_dep.c
@@ -2217,17 +2217,17 @@ void GC_register_data_segments(void)
                                     | (GC_pages_executable ? PROT_EXEC : 0),
                   GC_MMAP_FLAGS | OPT_MAP_ANON | MAP_32BIT, zero_fd, 0/* offset */);
 #   else
-    while ((size_t)last_addr < 1073741824L * 3) {
+    while ((size_t)last_addr < 1073741824L * 4) {
         result = mmap(last_addr, bytes, (PROT_READ | PROT_WRITE)
                                         | (GC_pages_executable ? PROT_EXEC : 0),
-                      GC_MMAP_FLAGS | OPT_MAP_ANON | MAP_FIXED, zero_fd, 0/* offset */);
+                      GC_MMAP_FLAGS | OPT_MAP_ANON | MAP_FIXED_NOREPLACE, zero_fd, 0/* offset */);
         if (result != MAP_FAILED) {
             break;
         }
         last_addr = (ptr_t)((size_t)last_addr + GC_page_size);
     }
 
-    if ((size_t)last_addr > 1073741824L * 3) {
+    if ((size_t)last_addr + bytes > 1073741824L * 4) {
         ABORT("Cannot allocate memory");
     }
 #   endif


### PR DESCRIPTION
* We should expand register 32-bit values into 64-bit
* When allocate memory, use MAP_FIXED_NOREPLACE instead of MAP_FIXED MAP_FIXED somtimes overwrite existing page
* Fix compile error with threading or LeakChecker